### PR TITLE
✨ Support multiple auto-includes on one line

### DIFF
--- a/bashpp
+++ b/bashpp
@@ -144,9 +144,8 @@ function preprocess() {
   while IFS= read -r line; do
     case "$line" in
       *::*)
-        if [[ "$line" =~ ([a-zA-Z0-9_]+)::([a-zA-Z0-9_]+) ]]; then
-          include_once "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
-        fi
+        grep -Eo '[a-zA-Z0-9_]+::[a-zA-Z0-9_]+' <<< "$line" |
+        	while read fn; do include_once ${fn//::/\/};done
         echo "$line"
       ;;
       "#include "*)


### PR DESCRIPTION
## 📑 What

When multiple functions are first used in a file on the same line, only the first gets included. This PR makes it so that all functions in such a case get included.

Fixes #3 

## ❓ Why

Currently, workarounds are needed in these cases, such as splitting onto multiple lines or adding a manual #include. This removes the need for such workarounds, making more concise code possible.

## ✅ Testing

Just needs regression testing. There should be no change in behavior for anything that currently works, and I've tested a few cases where behavior that would not have worked before now does, such as in #3.

- [X] I have tested my work
- [X] I need you to test it too
