### PR TITLE
✨ Pass through all arguments to Bash

### DIFF
--- a/bashp
+++ b/bashp
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-bashpc "${1:-/dev/stdin}" | bash
+bashpc "${1:-/dev/stdin}" | bash -s "$@"

--- a/bashpc
+++ b/bashpc
@@ -4,7 +4,7 @@ set -eo pipefail
 script=${1:-/dev/stdin}
 include_dir="$(dirname "$script")/libs"
 
-mkdir -p "$include_dir" || include_dir=$(mktemp -d)
+mkdir -p "$include_dir" 2>/dev/null || include_dir=$(mktemp -d)
 
 INCLUDE_DIR="$include_dir" \
 bashpp "$script" | sed '1s,^#!.*$,#!/usr/bin/env bash,'

--- a/bashpp
+++ b/bashpp
@@ -143,7 +143,7 @@ function preprocess() {
       *::*)
         local include
         grep -Eo '[a-zA-Z0-9_]+::[a-zA-Z0-9_]+' <<< "$line" |
-        	while read include; do include_once ${include//::/\/}; done
+          while read include; do include_once ${include//::/\/}; done
         echo "$line"
       ;;
       "#include "*)


### PR DESCRIPTION
<!-- PR Guidelines - Inspired by https://jesseduffield.com/Submitting-PRs/

* SELF-REVIEW YOUR PR: Read your PR thoroughly as if you were the reviewer.

* ADD REVIEWERS ONLY WHEN READY: Add reviewers only when the PR is ready (not
  a Draft).

* SEEK EARLY FEEDBACK: Start a Draft PR and add specific reviewers for early
  feedback. Note: CODEOWNERS are auto-assigned, cannot be removed, and
  disregard Draft PRs.

* SQUASH COMMITS BEFORE REVIEW: Squash commits for clarity and conciseness
  before review.

* AVOID FORCE PUSH DURING REVIEW: Avoid force pushing new commits after
  reviewers are assigned to ease change tracking. Squash again after approval
  if needed.

-->

## 📑 What

<!-- Add a brief description about this PR -->
<!-- If this pull request closes an issue, please mention the issue below -->
This PR makes two improvements:
1. Passes through all command line arguments to the bash interpreter in `bashp`
2. Suppresses `mkdir` error messages in `bashpc` when creating the include directory

## ❓ Why

<!-- Explain why you are making this change. Reference an issue -->
- Passing through all arguments (`"$@"`) ensures that any additional arguments provided to `bashp` are properly forwarded to the `bash` interpreter, making the script more flexible and allowing for proper argument handling
- Suppressing `mkdir` errors improves the user experience by hiding non-critical error messages

## ⚡ How to Review

<!-- Describe how you would like this PR to be reviewed -->
1. Review the changes in `bashp` to ensure proper argument passing
2. Verify the error redirection in `bashpc` is correctly implemented
3. Check that the changes maintain backward compatibility

## ✅ Testing

<!-- Make sure you have tested and how someone else would test if required -->

- [X] I have tested my work
- [ ] I need you to test it too

Test cases to verify:
1. Run `bashp` with various arguments to ensure they are passed through correctly
2. Verify that `bashpc` still works correctly when the include directory exists
3. Confirm that the script behaviour remains unchanged for basic usage without arguments