### PR TITLE
🐛 Fix assert_exit_code, improve exit code handling for all

### DIFF
--- a/libs/core/test/assert_exit_code
+++ b/libs/core/test/assert_exit_code
@@ -37,8 +37,18 @@ function core::test::assert_exit_code() {
   local expectedCode=${1:-${expectedCode:?must be set}}
   shift
 
+  local restoreExitOnError=false
+  if [[ $- =~ e ]]; then
+    restoreExitOnError=true
+  fi
+
+  set +e
   "$@" &>/dev/null
   local actualCode=$?
+  
+  if [[ $restoreExitOnError == true ]]; then
+    set -e
+  fi
 
   if [[ $actualCode -eq $expectedCode ]]; then
     echo "✅ Assertion passed: command '$*' exited with status $actualCode"

--- a/libs/core/test/assert_exit_code
+++ b/libs/core/test/assert_exit_code
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#include core/test/run_without_exit_on_error
+
 # core::test::assert_exit_code
 # Asserts that a command exits with a specific exit code.
 #
@@ -37,17 +39,8 @@ function core::test::assert_exit_code() {
   local expectedCode=${1:-${expectedCode:?must be set}}
   shift
 
-  local restoreExitOnError=false
-  if [[ $- =~ e ]]; then
-    restoreExitOnError=true
-  fi
-
-  set +e
-  "$@" &>/dev/null
-  local actualCode=$?
-  if [[ $restoreExitOnError == true ]]; then
-    set -e
-  fi
+  local actualCode
+  actualCode=$(core::test::run_without_exit_on_error "$@")
 
   if [[ $actualCode -eq $expectedCode ]]; then
     echo "✅ Assertion passed: command '$*' exited with status $actualCode"

--- a/libs/core/test/assert_exit_code
+++ b/libs/core/test/assert_exit_code
@@ -45,7 +45,6 @@ function core::test::assert_exit_code() {
   set +e
   "$@" &>/dev/null
   local actualCode=$?
-  
   if [[ $restoreExitOnError == true ]]; then
     set -e
   fi

--- a/libs/core/test/assert_failure
+++ b/libs/core/test/assert_failure
@@ -32,13 +32,23 @@
 # Example:
 #   core::test::assert_failure ls /nonexistent
 function core::test::assert_failure() {
-  local exitCode
-  if ! "$@" &>/dev/null; then
-    exitCode=$?
+  local restoreExitOnError=false
+  if [[ $- =~ e ]]; then
+    restoreExitOnError=true
+  fi
+
+  set +e
+  "$@" &>/dev/null
+  local exitCode=$?
+  
+  if [[ $restoreExitOnError == true ]]; then
+    set -e
+  fi
+
+  if [[ $exitCode -ne 0 ]]; then
     echo "✅ Assertion passed: command '$*' exited with status $exitCode"
     return 0
   else
-    exitCode=$?
     echo "⛔ Assertion failed: command '$*' exited with status $exitCode (expected non-zero)" >&2
     return 1
   fi

--- a/libs/core/test/assert_failure
+++ b/libs/core/test/assert_failure
@@ -40,7 +40,6 @@ function core::test::assert_failure() {
   set +e
   "$@" &>/dev/null
   local exitCode=$?
-  
   if [[ $restoreExitOnError == true ]]; then
     set -e
   fi

--- a/libs/core/test/assert_failure
+++ b/libs/core/test/assert_failure
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#include core/test/run_without_exit_on_error
+
 # core::test::assert_failure
 # Asserts that a command exits with a non-zero exit code.
 #
@@ -32,17 +34,8 @@
 # Example:
 #   core::test::assert_failure ls /nonexistent
 function core::test::assert_failure() {
-  local restoreExitOnError=false
-  if [[ $- =~ e ]]; then
-    restoreExitOnError=true
-  fi
-
-  set +e
-  "$@" &>/dev/null
-  local exitCode=$?
-  if [[ $restoreExitOnError == true ]]; then
-    set -e
-  fi
+  local exitCode
+  exitCode=$(core::test::run_without_exit_on_error "$@")
 
   if [[ $exitCode -ne 0 ]]; then
     echo "✅ Assertion passed: command '$*' exited with status $exitCode"

--- a/libs/core/test/assert_success
+++ b/libs/core/test/assert_success
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#include core/test/run_without_exit_on_error
+
 # core::test::assert_success
 # Asserts that a command exits successfully (exit code 0).
 #
@@ -31,17 +33,8 @@
 # Example:
 #   core::test::assert_success ls /tmp
 function core::test::assert_success() {
-  local restoreExitOnError=false
-  if [[ $- =~ e ]]; then
-    restoreExitOnError=true
-  fi
-
-  set +e
-  "$@" &>/dev/null
-  local exitCode=$?
-  if [[ $restoreExitOnError == true ]]; then
-    set -e
-  fi
+  local exitCode
+  exitCode=$(core::test::run_without_exit_on_error "$@")
 
   if [[ $exitCode -eq 0 ]]; then
     echo "✅ Assertion passed: command '$*' exited with status $exitCode"

--- a/libs/core/test/assert_success
+++ b/libs/core/test/assert_success
@@ -31,13 +31,23 @@
 # Example:
 #   core::test::assert_success ls /tmp
 function core::test::assert_success() {
-  local exitCode
-  if "$@" &>/dev/null; then
-    exitCode=0
+  local restoreExitOnError=false
+  if [[ $- =~ e ]]; then
+    restoreExitOnError=true
+  fi
+
+  set +e
+  "$@" &>/dev/null
+  local exitCode=$?
+  
+  if [[ $restoreExitOnError == true ]]; then
+    set -e
+  fi
+
+  if [[ $exitCode -eq 0 ]]; then
     echo "✅ Assertion passed: command '$*' exited with status $exitCode"
     return 0
   else
-    exitCode=$?
     echo "⛔ Assertion failed: command '$*' exited with status $exitCode (expected 0)" >&2
     return 1
   fi

--- a/libs/core/test/assert_success
+++ b/libs/core/test/assert_success
@@ -39,7 +39,6 @@ function core::test::assert_success() {
   set +e
   "$@" &>/dev/null
   local exitCode=$?
-  
   if [[ $restoreExitOnError == true ]]; then
     set -e
   fi

--- a/libs/core/test/run_without_exit_on_error
+++ b/libs/core/test/run_without_exit_on_error
@@ -1,0 +1,69 @@
+# shellcheck shell=bash
+#
+# Copyright 2025 The Linux Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# core::test::run_without_exit_on_error
+# Executes a command with 'set -e' and 'set -u' temporarily disabled, then restores the original state.
+#
+# Description:
+#   This helper function temporarily disables the 'set -e' (errexit) and 'set -u' (nounset)
+#   shell options before executing a command, allowing the command to return any exit code
+#   and reference undefined variables without causing the shell to exit. After execution,
+#   it restores the original shell option states and outputs the exit code to stdout.
+#   The function itself always returns 0 to prevent triggering 'set -e'.
+#   This is particularly useful in test assertions that need to capture and validate
+#   specific exit codes.
+#
+# Usage:
+#   exitCode=$(core::test::run_without_exit_on_error <command> [args...])
+#
+# Parameters:
+#   command - The command or function to execute.
+#   args... - Optional arguments to pass to the command.
+#
+# Outputs:
+#   The exit code of the executed command (to stdout).
+#
+# Example:
+#   exitCode=$(core::test::run_without_exit_on_error some_command arg1 arg2)
+function core::test::run_without_exit_on_error() {
+  local restoreExitOnError=false
+  local restoreUnsetVarError=false
+  
+  if [[ $- =~ e ]]; then
+    restoreExitOnError=true
+  fi
+  
+  if [[ $- =~ u ]]; then
+    restoreUnsetVarError=true
+  fi
+
+  set +e
+  set +u
+  "$@" &>/dev/null
+  local exitCode=$?
+  
+  if [[ $restoreExitOnError == true ]]; then
+    set -e
+  fi
+  
+  if [[ $restoreUnsetVarError == true ]]; then
+    set -u
+  fi
+
+  echo "$exitCode"
+  return 0
+}


### PR DESCRIPTION
<!-- PR Guidelines - Inspired by https://jesseduffield.com/Submitting-PRs/

* SELF-REVIEW YOUR PR: Read your PR thoroughly as if you were the reviewer.

* ADD REVIEWERS ONLY WHEN READY: Add reviewers only when the PR is ready (not
  a Draft).

* SEEK EARLY FEEDBACK: Start a Draft PR and add specific reviewers for early
  feedback. Note: CODEOWNERS are auto-assigned, cannot be removed, and
  disregard Draft PRs.

* SQUASH COMMITS BEFORE REVIEW: Squash commits for clarity and conciseness
  before review.

* AVOID FORCE PUSH DURING REVIEW: Avoid force pushing new commits after
  reviewers are assigned to ease change tracking. Squash again after approval
  if needed.

-->

## 📑 What

<!-- Add a brief description about this PR -->
<!-- If this pull request closes an issue, please mention the issue below -->
Fix exit code and options handling in `core::test::assert_exit_code`.
Improve exit code and options handling in all similar assert functions.

## ❓ Why

<!-- Explain why you are making this change. Reference an issue -->
As tests are getting added, tests that use `core::test::assert_exit_code`, all assert functions need to work reliably.

## ⚡ How to Review

<!-- Describe how you would like this PR to be reviewed -->

## ✅ Testing

<!-- Make sure you have tested and how someone else would test if required -->

- [X] I have tested my work
- [ ] I need you to test it too
