### PR TITLE
💚 Don't install buildx not to build multi-arch images

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -35,10 +35,6 @@ jobs:
             echo "package=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Set up Docker
-        if: steps.check.outputs.package == 'true'
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to GitHub Container Registry
         if: steps.check.outputs.package == 'true'
         uses: docker/login-action@v3


### PR DESCRIPTION
<!-- PR Guidelines - Inspired by https://jesseduffield.com/Submitting-PRs/

* SELF-REVIEW YOUR PR: Read your PR thoroughly as if you were the reviewer.

* ADD REVIEWERS ONLY WHEN READY: Add reviewers only when the PR is ready (not
  a Draft).

* SEEK EARLY FEEDBACK: Start a Draft PR and add specific reviewers for early
  feedback. Note: CODEOWNERS are auto-assigned, cannot be removed, and
  disregard Draft PRs.

* SQUASH COMMITS BEFORE REVIEW: Squash commits for clarity and conciseness
  before review.

* AVOID FORCE PUSH DURING REVIEW: Avoid force pushing new commits after
  reviewers are assigned to ease change tracking. Squash again after approval
  if needed.

-->

## 📑 What

<!-- Add a brief description about this PR -->
<!-- If this pull request closes an issue, please mention the issue below -->
Do not install `docker buildx` so that built images aren't build multi-arch.

## ❓ Why

<!-- Explain why you are making this change. Reference an issue -->

## ⚡ How to Review

<!-- Describe how you would like this PR to be reviewed -->

## ✅ Testing

<!-- Make sure you have tested and how someone else would test if required -->

- [ ] I have tested my work
- [ ] I need you to test it too
