### PR TITLE
Update GitHub Actions to current action versions

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check if all tests passed for this package
         id: check
@@ -37,10 +37,10 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: steps.check.outputs.package == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create temporary Dockerfile
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build and push Docker image
         if: steps.check.outputs.package == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./libs
           file: ./libs/Dockerfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create Release
         uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
       functions: ${{ steps.functions.outputs.matrix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get all packages
         id: packages
@@ -82,10 +82,10 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Test function
         id: test
@@ -99,11 +99,11 @@ jobs:
           exitCode=$?
           echo "$output"
 
-          if [[ $exitCcode -eq 0 ]]; then
+          if [[ $exitCode -eq 0 ]]; then
             echo "✅ Test passed for ${{ matrix.function.function }}"
-          elif [[ $exitCcode -eq 127 ]]; then
+          elif [[ $exitCode -eq 127 ]]; then
             echo "🔍 No test defined for ${{ matrix.function.function }} (acceptable)"
           else
-            echo "❌ Test failed for ${{ matrix.function.function }} (exit code: $exitCcode)"
+            echo "❌ Test failed for ${{ matrix.function.function }} (exit code: $exitCode)"
             echo "${{ matrix.function.package }}=false" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` v4 → v6 across package, test, and release workflows
- Bump `docker/login-action` v3 → v4 and `docker/build-push-action` v5 → v7 in the package workflow
- Bump `docker/setup-buildx-action` v3 → v4 in the test workflow
- Use `github.repository_owner` for GHCR login (matches exam-repo convention)
- Fix `$exitCcode` typo in `test.yaml` that prevented failed tests from being recorded

This clears the Node.js 20 deprecation warnings seen when `bashp-packages` calls the reusable package workflow.

## Test plan

- [ ] Merge and re-run **Build and Push Package Images** on `bashp-packages`
- [ ] Confirm logs no longer warn on `checkout@v4`, `login-action@v3`, or `build-push-action@v5`
- [ ] Verify package images still push to `ghcr.io/lf-certification/bashp-*`


Made with [Cursor](https://cursor.com)